### PR TITLE
Update sbt-jmh to fix profiling args

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,4 @@
 logLevel := Level.Warn
 
 // sbt-jmh plugin - pulls in JMH dependencies too
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.15")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.16")


### PR DESCRIPTION
There is a bug in the sbt-jmh version preventing use of the JFR profiling configuration. 
This is a simple version bump to address the issue. 